### PR TITLE
Workaround for Ubuntu 18.04 LTS: Lower minimal Python version requirement to 3.6

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ eth-keys = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.7"
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a3a3c675e571e062638b1099e85d5bbc0f83df850d446a2e16f268cedaa7e5ad"
+            "sha256": "1fc9579019ccf5e78c2993743292e8e33de406cbbd27d67de48843e0dba031a0"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.7"
+            "python_version": "3.6"
         },
         "sources": [
             {

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Repository aimed for internal use within OnGrid Systems team.
 
 ## Install
 * Clone the repository
+
+* Clean Ubuntu 18.04 LTS image: You'll have to install python, pip and pipenv first
+```sh
+sudo apt install python-pip python3-pip
+pip install pipenv
+```
+
 * Install node and python dependencies
 ```sh
 pipenv install


### PR DESCRIPTION
Требования к версии питона в pip-файлах 3.7 не подходят для удобного использовании на сборках Ubuntu 18.04 LTS  (bionic). В них штатная версия питона 3.6.8. Так как половина разработчиков использует подобный дистр - в данном pull-request предлагаю понизить требования к версии до 3.6, чтобы для пользователей Ubuntu также работал пошаговый гайд из README.md 